### PR TITLE
Removed deprecated use of n_iter in SGD-Classifer

### DIFF
--- a/Code/lucid_ml/run.py
+++ b/Code/lucid_ml/run.py
@@ -273,7 +273,7 @@ def create_classifier(options, num_concepts):
                      'lambdamart' : "6"}
 
     # --- BUILD CLASSIFIER ---
-    sgd = OneVsRestClassifier(SGDClassifier(loss='log', n_iter=options.max_iterations, verbose=max(0,options.verbose-2), penalty=options.penalty, alpha=options.alpha, average=True),
+    sgd = OneVsRestClassifier(SGDClassifier(loss='log', max_iter=options.max_iterations, verbose=max(0,options.verbose-2), penalty=options.penalty, alpha=options.alpha, average=True),
         n_jobs=options.jobs)
     logregress = OneVsRestClassifier(LogisticRegression(C=64, penalty='l2', dual=False, verbose=max(0,options.verbose-2)),
         n_jobs=options.jobs)


### PR DESCRIPTION
The use of `n_iter` in the `SGDClassifier` [has been marked as deprecated](http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier) in sklearn 0.19 and results in multiple deprecation warnings when running a `SGDClassifier`. Thus it has been updated to the newer `max_iter` attribute. This will prevent the deprecation warnings.